### PR TITLE
Add `libblockdev-crypto3` as alternative to `libblockdev-crypto2`

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -173,7 +173,7 @@ Depends: apparmor-profiles-kicksecure | dummy-dependency-apparmor-profiles-kicks
          iputils-ping,
          jitterentropy-rngd,
          less,
-         libblockdev-crypto2,
+         libblockdev-crypto2 | libblockdev-crypto3,
          libpam-tmpdir,
          lsof,
          man-db,


### PR DESCRIPTION
This pull request changes...

## Changes

`libblockdev-crypto3` replaces `libblockdev-crypto2` in Debian Trixie and higher. Debian Bookworm pulls in `libblockdev-crypto2` via a dependency by `udisks2`; in Trixie, `udisks2` depends on `libblockdev-crypto3` instead.

This fixes issues when distro-morphing Debian Trixie and higher to Kicksecure. It is also necessary for installing Kicksecure on ports-only architectures such as `ppc64`.

Incidentally, Trixie replaces Bookworm's `rec` with a `dep`, so it's conceivable that Kicksecure could drop the explicit dependency once Bookworm support is dropped.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [ ] I have tested it locally
    * It definitely gets Kicksecure to install and run on `ppc64`. I haven't tested it beyond that, though I'd be pretty surprised if this one has much potential to break things that weren't already broken.
- [ ] I have reviewed and updated any documentation if relevant
    * No relevant docs AFAICT.
- [ ] I am providing new code and test(s) for it
    * No new code per se, just a dependency version bump.
